### PR TITLE
Add `picocss` to package.json and update the `copy-vendor` command in Makefile accordingly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ install:
 
 .PHONY: copy-vendor
 copy-vendor:
+	@echo "Copying PicoCSS..."
+	mkdir -p $(TARGET_BASE_PATH)/picocss
+	cp -a $(SOURCE_BASE_PATH)/@picocss/pico/css/. $(TARGET_BASE_PATH)/picocss
 	@echo "Copying HTMX..."
 	mkdir -p $(TARGET_BASE_PATH)/htmx
 	cp -a $(SOURCE_BASE_PATH)/htmx.org/dist/. $(TARGET_BASE_PATH)/htmx

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/hasansezertasan"
   },
   "dependencies": {
+    "@picocss/pico": "2.0.6",
     "htmx.org": "1.9.12",
     "hx-take": "0.3.1",
     "hyperscript.org": "0.9.12",


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the Makefile to include commands for copying PicoCSS files to the target directory, ensuring that PicoCSS is properly integrated into the build process.

* **Build**:
    - Added `picocss` to the `copy-vendor` command in the Makefile, including commands to create the target directory and copy the PicoCSS files.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added PicoCSS library to enhance styling options.
- **Chores**
  - Updated build process to include PicoCSS files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->