### PR TITLE
Remove `sweetalert` and add `sweetalert2`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ copy-vendor:
 	@echo "Copying sortablejs..."
 	mkdir -p $(TARGET_BASE_PATH)/sortablejs
 	cp -a $(SOURCE_BASE_PATH)/sortablejs/. $(TARGET_BASE_PATH)/sortablejs
-	@echo "Copying sweetalert..."
-	mkdir -p $(TARGET_BASE_PATH)/sweetalert
-	cp -a $(SOURCE_BASE_PATH)/sweetalert/dist/. $(TARGET_BASE_PATH)/sweetalert
+	@echo "Copying sweetalert2..."
+	mkdir -p $(TARGET_BASE_PATH)/sweetalert2
+	cp -a $(SOURCE_BASE_PATH)/sweetalert2/dist/. $(TARGET_BASE_PATH)/sweetalert2
 	@echo "Copying uikit..."
 	mkdir -p $(TARGET_BASE_PATH)/uikit
 	cp -a $(SOURCE_BASE_PATH)/uikit/dist/. $(TARGET_BASE_PATH)/uikit

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "hx-take": "0.3.1",
     "hyperscript.org": "0.9.12",
     "sortablejs": "1.15.2",
-    "sweetalert": "2.1.2",
+    "sweetalert2": "^11.11.1",
     "uikit": "3.21.5"
   }
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the project by replacing the `sweetalert` library with `sweetalert2` in the Makefile, ensuring the project uses the newer version of the alert library.

* **Enhancements**:
    - Replaced `sweetalert` with `sweetalert2` in the Makefile to update the dependency.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency from `sweetalert` to `sweetalert2` for improved alert functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->